### PR TITLE
Fixed clientConnected callback: This will always be called from a non…

### DIFF
--- a/app/src/main/java/com/example/testsnowflakeproxy/MainActivity.kt
+++ b/app/src/main/java/com/example/testsnowflakeproxy/MainActivity.kt
@@ -39,9 +39,11 @@ class MainActivity : AppCompatActivity() {
 
         start.setOnClickListener {
             IPtProxy.startSnowflakeProxy(capacity, broker, relay, stun, logFile, keepLocalAddresses, unsafeLogging) {
-                count++
-                Toast.makeText(this, "Client connected", Toast.LENGTH_LONG).show()
-                label.text = "Connected Clients: $count"
+                runOnUiThread {
+                    count++
+                    Toast.makeText(this, "Client connected", Toast.LENGTH_LONG).show()
+                    label.text = "Connected Clients: $count"
+                }
             }
         }
 


### PR DESCRIPTION
…-UI thread, so you need to switch to the UI thread before manipulating the UI.

Unfortunately, the JNI crash, this triggers, takes a while. Seems there's a timeout going on, so it's not easy to spot.